### PR TITLE
Increase the range of ignored pages to include all hidden directories

### DIFF
--- a/pages/pages.go
+++ b/pages/pages.go
@@ -110,7 +110,7 @@ func Load(root string) (pages map[string]*Resp, err error) {
 		}
 
 		// Ignore our .git folder.
-		if fi.IsDir() && fi.Name() == ".git" {
+		if fi.IsDir() && fi.Name()[0] == '.' {
 			return filepath.SkipDir
 		}
 		dirs = append(dirs, path)


### PR DESCRIPTION
`.github` dir broke taitan, so we exclude it

The same will probably be true for other eventual hidden stuff, so I think it s best to just exclude them all now