### PR TITLE
Add support for default expanded tag in meta.toml

### DIFF
--- a/taitan.go
+++ b/taitan.go
@@ -290,7 +290,7 @@ func handler(res http.ResponseWriter, req *http.Request) {
 			responses.Resps[slug].Title,
 			strings.FieldsFunc(slug, func(c rune) bool { return c == '/' }),
 			false,
-			false,
+			responses.Resps[slug].Expanded,
 			responses.Resps[slug].Sort,
 		)
 		// }


### PR DESCRIPTION
Allows you to add the field `Expanded: true` to a directory `meta.toml` file, which will make the nav-tree always include the children of node if it is included in the tree.