### PR TITLE
Include more header levels in achor list

### DIFF
--- a/anchor/anchor.go
+++ b/anchor/anchor.go
@@ -1,6 +1,7 @@
 package anchor
 
 import (
+	"strconv"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -12,6 +13,7 @@ import (
 type Anchor struct {
 	ID    string `json:"id"`    // Id of h2 element.
 	Value string `json:"value"` // Value inside the anchor tag.
+	Level int    `json:"level"`
 }
 
 // Anchors finds <h1> elements inside a HTML string to create a list of anchors.
@@ -24,7 +26,7 @@ func Anchors(body string) (anchs []Anchor, err error) {
 	// Recursively find <h1> elements.
 	var findAnchors func(*html.Node)
 	findAnchors = func(n *html.Node) {
-		if n.Type == html.ElementNode && n.Data == "h2" {
+		if n.Type == html.ElementNode && n.Data[0] == 'h' {
 			// Append valid anchors.
 			anchs = anchor(n, anchs)
 		}
@@ -44,9 +46,12 @@ func anchor(n *html.Node, anchs []Anchor) []Anchor {
 	if val == "" && id == "" {
 		return anchs
 	}
+	headerLevel, _ := strconv.Atoi(n.Data[1:])
+
 	return append(anchs, Anchor{
 		ID:    id,
 		Value: val,
+		Level: headerLevel,
 	})
 }
 

--- a/anchor/anchor.go
+++ b/anchor/anchor.go
@@ -26,7 +26,7 @@ func Anchors(body string) (anchs []Anchor, err error) {
 	// Recursively find <h1> elements.
 	var findAnchors func(*html.Node)
 	findAnchors = func(n *html.Node) {
-		if n.Type == html.ElementNode && n.Data[0] == 'h' {
+		if isHNode(n) {
 			// Append valid anchors.
 			anchs = anchor(n, anchs)
 		}
@@ -73,4 +73,19 @@ func plain(n *html.Node) string {
 		return plain(c)
 	}
 	return ""
+}
+
+func isHNode(n *html.Node) bool {
+	if n.Type != html.ElementNode {
+		return false
+	}
+
+	tags := []string{"h1", "h2", "h3", "h4", "h5", "h6"}
+	for _, tag := range tags {
+		if tag == n.Data {
+			return true
+		}
+	}
+
+	return false
 }

--- a/anchor/anchor.go
+++ b/anchor/anchor.go
@@ -10,20 +10,22 @@ import (
 
 // Anchor is a html anchor tag with an id attribute and a value. Represents: <a
 // id="Id">Value</a>
+// It is intended to link to titles in the document
 type Anchor struct {
-	ID    string `json:"id"`    // Id of h2 element.
-	Value string `json:"value"` // Value inside the anchor tag.
-	Level int    `json:"level"`
+	ID          string `json:"id"`    // Id of the h* element.
+	Value       string `json:"value"` // Value inside the anchor tag.
+	HeaderLevel int    `json:"level"` // Level of the h* element.
 }
 
-// Anchors finds <h1> elements inside a HTML string to create a list of anchors.
+// Anchors finds <h*> elements inside a HTML string to create a list of anchors.
 func Anchors(body string) (anchs []Anchor, err error) {
 	node, err := html.Parse(strings.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
 	anchs = make([]Anchor, 0)
-	// Recursively find <h1> elements.
+
+	// Recursively find <h*> elements.
 	var findAnchors func(*html.Node)
 	findAnchors = func(n *html.Node) {
 		if isHNode(n) {
@@ -49,9 +51,9 @@ func anchor(n *html.Node, anchs []Anchor) []Anchor {
 	headerLevel, _ := strconv.Atoi(n.Data[1:])
 
 	return append(anchs, Anchor{
-		ID:    id,
-		Value: val,
-		Level: headerLevel,
+		ID:          id,
+		Value:       val,
+		HeaderLevel: headerLevel,
 	})
 }
 


### PR DESCRIPTION
Expand the amount levels of `h*` tags to include in the anchors list, to be more than `h2` tags (but including data for determining which level of header).

This is used for the right sidebars in the `bawang`s, and this change would make it more flexible what to display in those.

The current behavior is especially annoying in `styrdokument-bawang`.

Will change the looks of our website and styrdokument without changing stuff in their `bawang`s, but that might or might not be basically ready already :wink:.