### PR TITLE
Allow hiding sensitive content

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 CONTENT_URL=https://github.com/datasektionen/bawang-content.git
 TOKEN=
+DARKMODE_URL=https://darkmode.datasektionen.se/

--- a/README.md
+++ b/README.md
@@ -35,12 +35,13 @@ GET /:path
 
 ### Environment variables
 
-| Name        | Description                                                                             |
-|-------------|-----------------------------------------------------------------------------------------|
-| PORT        | The port to listen to requests on                                                       |
-| TOKEN       | GitHub Personal Access Token used for authorization when pulling the content repository. (Only needed if the content repo is private) |
-| CONTENT_URL | The repository to get content from                                                      |
-| CONTENT_DIR | Directory to serve contents from. Setting this disables the automatic fetching using git and makes the `TOKEN` and `CONTENT_URL` unused. |
+| Name         | Description                                                                                                                              |
+|--------------|------------------------------------------------------------------------------------------------------------------------------------------|
+| PORT         | The port to listen to requests on                                                                                                        |
+| TOKEN        | GitHub Personal Access Token used for authorization when pulling the content repository. (Only needed if the content repo is private)    |
+| CONTENT_URL  | The repository to get content from                                                                                                       |
+| CONTENT_DIR  | Directory to serve contents from. Setting this disables the automatic fetching using git and makes the `TOKEN` and `CONTENT_URL` unused. |
+| DARKMODE_URL | URL to the darkmode system, or `true` or `false` to use that value instead of sending an http request.                                   |
 
 ### Flags
 

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,6 @@
 module github.com/datasektionen/taitan
 
-// +heroku goVersion go1.15
-go 1.15
+go 1.22.1
 
 require (
 	github.com/BurntSushi/toml v0.3.1
@@ -10,3 +9,5 @@ require (
 	github.com/sirupsen/logrus v1.7.0
 	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
 )
+
+require golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rjeczalik/notify v0.9.2 h1:MiTWrPj55mNDHEiIX5YUSKefw/+lCQVoAFmD6oQm5w8=
 github.com/rjeczalik/notify v0.9.2/go.mod h1:aErll2f0sUX9PXZnVNyeiObbmTlk5jnMoCa4QEjJeqM=
@@ -8,6 +10,7 @@ github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3V
 github.com/russross/blackfriday v1.6.0/go.mod h1:ti0ldHuxg49ri4ksnFxlkCfN+hvslNlmVHqNRXXJNAY=
 github.com/sirupsen/logrus v1.7.0 h1:ShrD1U9pZB12TX0cVy0DtePoCH97K8EtX+mg7ZARUtM=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
@@ -17,7 +20,6 @@ golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/sys v0.0.0-20180926160741-c2ed4eda69e7/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193GlqGZbnPFnPV/5Rsb4=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/pages/pages.go
+++ b/pages/pages.go
@@ -1,7 +1,6 @@
 package pages
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -175,7 +174,7 @@ func parseDirs(root string, dirs []string) (pages map[string]*Resp, err error) {
 
 // toHTML reads a markdown file and returns a HTML string.
 func toHTML(filename string) (string, error) {
-	buf, err := ioutil.ReadFile(filename)
+	buf, err := os.ReadFile(filename)
 	if err != nil {
 		return "", err
 	}

--- a/taitan.go
+++ b/taitan.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -21,10 +20,10 @@ import (
 )
 
 var (
-	debug      bool   // Show debug level messages.
-	info       bool   // Show info level messages.
-	watch      bool   // Watch for file changes.
-	responses  Atomic // Our parsed responses.
+	debug     bool   // Show debug level messages.
+	info      bool   // Show info level messages.
+	watch     bool   // Watch for file changes.
+	responses Atomic // Our parsed responses.
 )
 
 func usage() {
@@ -200,7 +199,7 @@ func main() {
 func updateJumpFile(root string) {
 	// If jumpfile exists.
 	if _, err := os.Stat(root + "/jumpfile.json"); err == nil {
-		buf, err := ioutil.ReadFile(root + "/jumpfile.json")
+		buf, err := os.ReadFile(root + "/jumpfile.json")
 		if err != nil {
 			log.Warningln("jumpfile readfile: unexpected error:", err)
 		}

--- a/taitan.go
+++ b/taitan.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/datasektionen/taitan/fuzz"
 	"github.com/datasektionen/taitan/pages"
@@ -148,8 +149,13 @@ func main() {
 	root := getRoot()
 	log.WithField("Root", root).Info("Our root directory")
 
+	isReception, err := getDarkmode()
+	if err != nil {
+		panic(err)
+	}
+
 	// We'll parse and store the responses ahead of time.
-	resps, err := pages.Load(root)
+	resps, err := pages.Load(isReception, root)
 	if err != nil {
 		log.Fatalf("pages.Load: unexpected error: %s", err)
 	}
@@ -179,7 +185,7 @@ func main() {
 		go func() {
 			for event := range events {
 				log.Info("event:", event)
-				resps, err := pages.Load(root)
+				resps, err := pages.Load(isReception, root)
 				if err == nil {
 					responses.Resps = resps
 				} else {
@@ -242,15 +248,21 @@ func handler(res http.ResponseWriter, req *http.Request) {
 	if req.Header.Get("X-Github-Event") == "push" {
 		log.Infoln("Push hook")
 		getContent()
-		resps, err := pages.Load(getRoot())
-		if err == nil {
-			responses.Lock()
-			responses.Resps = resps
-			responses.Unlock()
-		} else {
+		isReception, err := getDarkmode()
+		if err != nil {
+			log.Warn("Could not get darkmode status: ", err)
+			res.WriteHeader(http.StatusNotAcceptable)
+			return
+		}
+		resps, err := pages.Load(isReception, getRoot())
+		if err != nil {
 			log.Warn("Ignoring update: ", err)
 			res.WriteHeader(http.StatusNotAcceptable)
+			return
 		}
+		responses.Lock()
+		responses.Resps = resps
+		responses.Unlock()
 
 		updateJumpFile(getRoot())
 		return
@@ -323,4 +335,35 @@ func rootDir(path string) string {
 		path = test
 	}
 	return path
+}
+
+var darkmode struct {
+	mu     sync.Mutex
+	result bool
+}
+
+func getDarkmode() (bool, error) {
+	darkmode.mu.Lock()
+	defer darkmode.mu.Unlock()
+
+	url := getEnv("DARKMODE_URL")
+	if url == "true" {
+		darkmode.result = true
+		return true, nil
+	}
+	if url == "false" {
+		darkmode.result = false
+		return false, nil
+	}
+
+	res, err := http.Get(url)
+	if err != nil {
+		return true, err
+	}
+	if err := json.NewDecoder(res.Body).Decode(&darkmode.result); err != nil {
+		return true, err
+	}
+	log.Info("Darkmode status: ", darkmode.result)
+
+	return darkmode.result, nil
 }


### PR DESCRIPTION
Parts of a page can be hidden during mörkläggningen (as reported by ) by wrapping it in an element with an attribute named `sensitive`. An element like this will normally be replaced by it's children but recursively removed during mörkläggningen. To specify alternative text during mörkläggningen, stuff can be wrapped in an element with an attribute named `fallback`.

A whole page can also be removed during mörkläggningen by putting `Sensitive = true` in it's `meta.toml`. That does however not remove it's sub-pages, although the links to them won't show up since that is usually at the parent.

Currently, the darkmode status is only checked on startup and when the content repository webhook runs (i.e. when the content repository is parsed). Perhaps this should be re-checked every now and then?