### PR TITLE
Add language support

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,4 +51,5 @@ jobs:
           NOMAD_ADDR: ${{ vars.NOMAD_ADDR }}
           NOMAD_TOKEN: ${{ secrets.NOMAD_TOKEN }}
         run: |
-          nomad run -var=image_tag=${{ env.current }} job.nomad.hcl
+          nomad run -var=bawang_image_tag=${{ env.current }} -var=styrdokument_image_tag=f1e1398 job.nomad.hcl
+          #                                                                              todo: remove this hardcoded thingie whence styrdokument-bawang is ready for new taitan

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Some notable behaviours:
 | CONTENT_URL  | The repository to get content from                                                                                                       |
 | CONTENT_DIR  | Directory to serve contents from. Setting this disables the automatic fetching using git and makes the `TOKEN` and `CONTENT_URL` unused. |
 | DARKMODE_URL | URL to the darkmode system, or `true` or `false` to use that value instead of sending an http request.                                   |
+| DEFAULT_LANG |  The default language code that will be used for responses if a `lang` parameter is not passed in an API request.                        |
 
 ### Flags
 

--- a/fuzz/fuzz.go
+++ b/fuzz/fuzz.go
@@ -21,11 +21,19 @@ type Fuzz struct {
 }
 
 // NewFile returns a fuzzyfile.
-func NewFile(resp map[string]*pages.Resp) File {
+func NewFile(resp map[string]*pages.RespStore) File {
 	fs := make([]Fuzz, 0, 128)
 	for path, r := range resp {
+		title, ok := r.Titles[""]
+		if !ok {
+			for _, title_ := range r.Titles {
+				title = title_
+				break
+			}
+		}
+
 		fs = append(fs, Fuzz{
-			Name: r.Title,
+			Name: title,
 			Str:  r.Slug,
 			Href: fmt.Sprintf("http://datasektionen.se%s", path),
 		})

--- a/fuzz/fuzz.go
+++ b/fuzz/fuzz.go
@@ -21,7 +21,7 @@ type Fuzz struct {
 }
 
 // NewFile returns a fuzzyfile.
-func NewFile(resp map[string]*pages.RespStore) File {
+func NewFile(resp map[string]*pages.Page) File {
 	fs := make([]Fuzz, 0, 128)
 	for path, r := range resp {
 		title, ok := r.Titles[""]

--- a/job.nomad.hcl
+++ b/job.nomad.hcl
@@ -25,7 +25,7 @@ job "taitan" {
       driver = "docker"
 
       config {
-        image = var.image_tag
+        image = var.bawang_image_tag
         ports = ["http"]
       }
 
@@ -70,7 +70,7 @@ ENV
       driver = "docker"
 
       config {
-        image = var.image_tag
+        image = var.styrdokument_image_tag
         ports = ["http"]
       }
 
@@ -92,7 +92,12 @@ ENV
   }
 }
 
-variable "image_tag" {
+variable "bawang_image_tag" {
+  type = string
+  default = "ghcr.io/datasektionen/taitan:latest"
+}
+
+variable "styrdokument_image_tag" {
   type = string
   default = "ghcr.io/datasektionen/taitan:latest"
 }

--- a/pages/pages.go
+++ b/pages/pages.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"text/template"
@@ -18,20 +19,22 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// Resp is the response we serve for file queries.
-type Resp struct {
-	Title     string          `json:"title"` // Human-readable title.
-	Slug      string          `json:"slug"`  // URL-slug.
-	URL       string          `json:"url"`
-	UpdatedAt string          `json:"updated_at"` // Body update time.
-	Image     string          `json:"image"`      // Path/URL/Placeholder to image.
-	Message   string          `json:"message"`    // Message to show at top
-	Body      string          `json:"body"`       // Main content of the page.
-	Sidebar   string          `json:"sidebar"`    // The sidebar of the page.
-	Sort      *int            `json:"sort"`       // The order that the tab should appear in on the page
-	Expanded  bool            `json:"expanded"`   // Should the Nav-tree rooted in this node always be expanded one step when loaded?
-	Anchors   []anchor.Anchor `json:"anchors"`    // The list of anchors to headers in the body.
-	Nav       []*Node         `json:"nav,omitempty"`
+type LangLookup map[string]string
+type LangAnchorLookup map[string][]anchor.Anchor
+
+// TODO: Better type name
+type RespStore struct {
+	Titles    LangLookup                 // Human-readable title.
+	Slug      string                     // URL-slug.
+	URL       string                     // Actual url?
+	UpdatedAt LangLookup                 // Page update time.
+	Image     string                     // Path/URL/Placeholder to image.
+	Message   string                     // Message to show at top
+	Bodies    LangLookup                 // Main content of the page.
+	Sidebars  LangLookup                 // The sidebar of the page.
+	Sort      *int                       // The order that the tab should appear in on the page
+	Expanded  bool                       // Should the Nav-tree rooted in this node always be expanded one step when loaded?
+	Anchors   map[string][]anchor.Anchor // The list of anchors to headers in the body.
 }
 
 // Node is a recursive node in a page tree.
@@ -132,9 +135,9 @@ func (n *Node) Num() int {
 }
 
 // Load intializes a root directory and serves all sub-folders.
-func Load(isReception bool, root string) (pages map[string]*Resp, err error) {
+func Load(isReception bool, root string) (map[string]*RespStore, error) {
 	var dirs []string
-	err = filepath.Walk(root, func(path string, fi os.FileInfo, err error) error {
+	err := filepath.Walk(root, func(path string, fi os.FileInfo, err error) error {
 		// We only search for article directories.
 		if !fi.IsDir() {
 			return nil
@@ -162,8 +165,8 @@ func stripRoot(root string, dir string) string {
 
 // parseDirs parses each directory into a response. Returns a map from requested
 // urls into responses.
-func parseDirs(isReception bool, root string, dirs []string) (pages map[string]*Resp, err error) {
-	pages = map[string]*Resp{}
+func parseDirs(isReception bool, root string, dirs []string) (map[string]*RespStore, error) {
+	pages := make(map[string]*RespStore)
 	for _, dir := range dirs {
 		r, err := parseDir(isReception, root, dir)
 		if err != nil {
@@ -207,43 +210,68 @@ func toHTML(isReception bool, filename string) (string, error) {
 }
 
 // parseDir creates a response for a directory.
-func parseDir(isReception bool, root, dir string) (*Resp, error) {
+func parseDir(isReception bool, root, dir string) (*RespStore, error) {
 	log.WithField("dir", dir).Debug("Parsing directory:")
 
-	// Our content files.
-	var (
-		bodyPath    = filepath.Join(dir, "body.md")
-		sidebarPath = filepath.Join(dir, "sidebar.md")
-		metaPath    = filepath.Join(dir, "meta.toml")
+	const (
+		bodyPattern     = "body(_\\w[2])?.md"
+		sidebarPattern  = "sidebar(_\\w[2])?.md"
+		titlePattern    = "Title(_\\w[2])?"
+		metaFile        = "meta.toml"
+		iso8601DateTime = "2006-01-02T15:04:05Z"
 	)
 
-	// Parse markdown to HTML.
-	body, err := toHTML(isReception, bodyPath)
-	if err != nil {
-		return nil, err
-	}
-	log.WithField("body", body).Debug("HTML of body.md")
+	bodyMap := make(LangLookup)
+	sidebarMap := make(LangLookup)
+	commitMap := make(LangLookup)
+	anchorsMap := make(map[string][]anchor.Anchor)
+	bodyReg := regexp.MustCompile(bodyPattern)
+	sidebarReg := regexp.MustCompile(sidebarPattern)
 
-	// Parse sidebar to HTML.
-	sidebar, err := toHTML(isReception, sidebarPath)
-	if err != nil {
-		return nil, err
-	}
-	log.WithField("sidebar", sidebar).Debug("HTML of sidebar.md")
+	stuff, err := os.ReadDir(dir)
 
-	// Get commit time
-	commitTime, err := getCommitTime(root, bodyPath)
-	if err != nil {
-		return nil, err
-	}
+	for _, file := range stuff {
+		filePath := filepath.Join(dir, file.Name())
 
-	// Parse anchors in the body.
-	anchs, err := anchor.Anchors(body)
-	if err != nil {
-		return nil, err
+		if match := bodyReg.FindSubmatch([]byte(file.Name())); match != nil {
+			lang := ""
+			if len(match) > 1 {
+				lang = string(match[1][:])
+			}
+			bodyMap[lang], err = toHTML(isReception, filePath)
+			log.WithField("body", bodyMap[lang]).Debug("HTML of body_" + lang + ".md")
+			if err != nil {
+				return nil, err
+			}
+
+			commitTime, err := getCommitTime(root, filePath)
+			if err != nil {
+				return nil, err
+			}
+			commitMap[lang] = commitTime.Format(iso8601DateTime)
+
+			// Parse anchors in the body.
+			anchorsMap[lang], err = anchor.Anchors(bodyMap[lang])
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		if match := sidebarReg.FindSubmatch([]byte(file.Name())); match != nil {
+			lang := ""
+			if len(match) > 1 {
+				lang = string(match[1][:])
+			}
+			sidebarMap[lang], err = toHTML(isReception, filePath)
+			log.WithField("sidebar", sidebarMap[lang]).Debug("HTML of sidebar" + lang + ".md")
+			if err != nil {
+				return nil, err
+			}
+		}
 	}
 
 	// Parse meta data from a toml file.
+	metaPath := filepath.Join(dir, metaFile)
 	var meta = Meta{
 		Sort:     nil, // all pages without a sort-tag should be after the pages with a sort-tag, but should keep their internal order
 		Expanded: false,
@@ -256,16 +284,15 @@ func parseDir(isReception bool, root, dir string) (*Resp, error) {
 		return nil, nil
 	}
 
-	const iso8601DateTime = "2006-01-02T15:04:05Z"
-	return &Resp{
-		Title:     meta.Title,
+	return &RespStore{
+		Titles:    meta.Title,
 		Slug:      filepath.Base(stripRoot(root, dir)),
-		UpdatedAt: commitTime.Format(iso8601DateTime),
+		UpdatedAt: commitMap,
 		Image:     meta.Image,
 		Message:   meta.Message,
-		Body:      body,
-		Sidebar:   sidebar,
-		Anchors:   anchs,
+		Bodies:    bodyMap,
+		Sidebars:  sidebarMap,
+		Anchors:   anchorsMap,
 		Expanded:  meta.Expanded,
 		Sort:      meta.Sort,
 	}, nil

--- a/pages/pages.go
+++ b/pages/pages.go
@@ -214,9 +214,9 @@ func parseDir(isReception bool, root, dir string) (*RespStore, error) {
 	log.WithField("dir", dir).Debug("Parsing directory:")
 
 	const (
-		bodyPattern     = "body(_\\w{2})?\\.md"
-		sidebarPattern  = "sidebar(_\\w{2})?\\.md"
-		titlePattern    = "Title(_\\w{2})?"
+		bodyPattern     = "body(_\\w+)\\.md"
+		sidebarPattern  = "sidebar(_\\w+)\\.md"
+		titlePattern    = "Title(_\\w+)"
 		metaFile        = "meta.toml"
 		iso8601DateTime = "2006-01-02T15:04:05Z"
 	)

--- a/pages/pages.go
+++ b/pages/pages.go
@@ -57,6 +57,17 @@ type Meta struct {
 	Sensitive bool
 }
 
+const (
+	metaFile        = "meta.toml"
+	iso8601DateTime = "2006-01-02T15:04:05Z"
+)
+
+var (
+	bodyReg    = regexp.MustCompile("body(_\\w+)\\.md")
+	sidebarReg = regexp.MustCompile("sidebar(_\\w+)\\.md")
+	titleReg   = regexp.MustCompile("Title(_\\w+)")
+)
+
 // NewNode creates a new node with it's path, slug and page title.
 func NewNode(path, slug, title string) *Node {
 	return &Node{path: path, Slug: slug, Title: title, Nav: make([]*Node, 0)}
@@ -211,18 +222,6 @@ func toHTML(isReception bool, filename string) (string, error) {
 // parseDir creates a response for a directory.
 func parseDir(isReception bool, root, dir string) (*Page, error) {
 	log.WithField("dir", dir).Debug("Parsing directory:")
-
-	const (
-		bodyPattern     = "body(_\\w+)\\.md"
-		sidebarPattern  = "sidebar(_\\w+)\\.md"
-		titlePattern    = "Title(_\\w+)"
-		metaFile        = "meta.toml"
-		iso8601DateTime = "2006-01-02T15:04:05Z"
-	)
-
-	bodyReg := regexp.MustCompile(bodyPattern)
-	sidebarReg := regexp.MustCompile(sidebarPattern)
-	titleReg := regexp.MustCompile(titlePattern)
 
 	bodies := make(LangLookup)
 	sidebars := make(LangLookup)

--- a/pages/pages.go
+++ b/pages/pages.go
@@ -249,9 +249,10 @@ func parseDir(isReception bool, root, dir string) (*RespStore, error) {
 
 			commitTime, err := getCommitTime(root, filePath)
 			if err != nil {
-				return nil, err
+				commitTimes[lang] = time.Now().Format(iso8601DateTime)
+			} else {
+				commitTimes[lang] = commitTime.Format(iso8601DateTime)
 			}
-			commitTimes[lang] = commitTime.Format(iso8601DateTime)
 
 			// Parse anchors in the body.
 			anchorsLists[lang], err = anchor.Anchors(bodies[lang])

--- a/pages/pages.go
+++ b/pages/pages.go
@@ -49,12 +49,12 @@ type Node struct {
 
 // Meta defines the attributes to be loaded from the meta.toml file
 type Meta struct {
-	Image     string
-	Title     string
-	Message   string
-	Sort      *int
-	Expanded  bool
-	Sensitive bool
+	Image     string     `toml:"image"`
+	Titles    LangLookup `toml:"title"`
+	Message   string     `toml:"message"`
+	Sort      *int       `toml:"sort"`
+	Expanded  bool       `toml:"expanded"`
+	Sensitive bool       `toml:"sensitive"`
 }
 
 const (
@@ -65,7 +65,6 @@ const (
 var (
 	bodyReg    = regexp.MustCompile("body(_\\w+)\\.md")
 	sidebarReg = regexp.MustCompile("sidebar(_\\w+)\\.md")
-	titleReg   = regexp.MustCompile("Title(_\\w+)")
 )
 
 // NewNode creates a new node with it's path, slug and page title.
@@ -226,7 +225,6 @@ func parseDir(isReception bool, root, dir string) (*Page, error) {
 	bodies := make(LangLookup)
 	sidebars := make(LangLookup)
 	commitTimes := make(LangLookup)
-	titles := make(LangLookup)
 	anchorsLists := make(LangAnchorLookup)
 
 	entries, err := os.ReadDir(dir)
@@ -294,21 +292,9 @@ func parseDir(isReception bool, root, dir string) (*Page, error) {
 	if meta.Sensitive && isReception {
 		return nil, nil
 	}
-	for k, v := range metaMap {
-		if match := titleReg.FindSubmatch([]byte(k)); match != nil {
-			switch v.(type) {
-			case string:
-				lang := ""
-				if len(match) > 1 && len(match[1]) > 0 {
-					lang = string(match[1][1:])
-				}
-				titles[lang] = v.(string)
-			}
-		}
-	}
 
-		Titles:    titles,
 	return &Page{
+		Titles:    meta.Titles,
 		Slug:      filepath.Base(stripRoot(root, dir)),
 		UpdatedAt: commitTimes,
 		Image:     meta.Image,

--- a/pages/pages.go
+++ b/pages/pages.go
@@ -22,8 +22,7 @@ import (
 type LangLookup map[string]string
 type LangAnchorLookup map[string][]anchor.Anchor
 
-// TODO: Better type name
-type RespStore struct {
+type Page struct {
 	Titles    LangLookup       // Human-readable title.
 	Slug      string           // URL-slug.
 	URL       string           // Actual url?
@@ -135,7 +134,7 @@ func (n *Node) Num() int {
 }
 
 // Load intializes a root directory and serves all sub-folders.
-func Load(isReception bool, root string) (map[string]*RespStore, error) {
+func Load(isReception bool, root string) (map[string]*Page, error) {
 	var dirs []string
 	err := filepath.Walk(root, func(path string, fi os.FileInfo, err error) error {
 		// We only search for article directories.
@@ -165,8 +164,8 @@ func stripRoot(root string, dir string) string {
 
 // parseDirs parses each directory into a response. Returns a map from requested
 // urls into responses.
-func parseDirs(isReception bool, root string, dirs []string) (map[string]*RespStore, error) {
-	pages := make(map[string]*RespStore)
+func parseDirs(isReception bool, root string, dirs []string) (map[string]*Page, error) {
+	pages := make(map[string]*Page)
 	for _, dir := range dirs {
 		r, err := parseDir(isReception, root, dir)
 		if err != nil {
@@ -210,7 +209,7 @@ func toHTML(isReception bool, filename string) (string, error) {
 }
 
 // parseDir creates a response for a directory.
-func parseDir(isReception bool, root, dir string) (*RespStore, error) {
+func parseDir(isReception bool, root, dir string) (*Page, error) {
 	log.WithField("dir", dir).Debug("Parsing directory:")
 
 	const (
@@ -309,8 +308,8 @@ func parseDir(isReception bool, root, dir string) (*RespStore, error) {
 		}
 	}
 
-	return &RespStore{
 		Titles:    titles,
+	return &Page{
 		Slug:      filepath.Base(stripRoot(root, dir)),
 		UpdatedAt: commitTimes,
 		Image:     meta.Image,

--- a/taitan.go
+++ b/taitan.go
@@ -260,6 +260,7 @@ func handler(res http.ResponseWriter, req *http.Request) {
 		log.Infoln("Redirect: " + newURL)
 		return
 	}
+
 	if req.URL.Path == "/fuzzyfile" {
 		log.Info("Fuzzyfile")
 		responses.Lock()
@@ -300,6 +301,8 @@ func handler(res http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	lang := req.URL.Query().Get("lang")
+
 	// Requested URL. We extract the path.
 	query := req.URL.Path
 	log.WithField("query", query).Info("Received query")
@@ -315,8 +318,6 @@ func handler(res http.ResponseWriter, req *http.Request) {
 		res.WriteHeader(http.StatusNotFound)
 		return
 	}
-
-	lang := req.URL.Query().Get("lang")
 
 	// Sort the slugs
 	var slugs []string

--- a/taitan.go
+++ b/taitan.go
@@ -134,7 +134,7 @@ func setVerbosity() {
 // Atomic responses.
 type Atomic struct {
 	sync.Mutex
-	Resps map[string]*pages.RespStore
+	Resps map[string]*pages.Page
 }
 
 func validRoot(root string) {
@@ -249,7 +249,7 @@ type Resp struct {
 	Nav       []*pages.Node   `json:"nav,omitempty"`
 }
 
-func responseExistForLang(resp *pages.RespStore, lang string) bool {
+func responseExistForLang(resp *pages.Page, lang string) bool {
 	if _, ok := resp.Titles[lang]; !ok {
 		return false
 	}

--- a/taitan.go
+++ b/taitan.go
@@ -302,6 +302,9 @@ func handler(res http.ResponseWriter, req *http.Request) {
 	}
 
 	lang := req.URL.Query().Get("lang")
+	if lang == "" {
+		lang = getEnv("DEFAULT_LANG")
+	}
 
 	// Requested URL. We extract the path.
 	query := req.URL.Path

--- a/taitan.go
+++ b/taitan.go
@@ -327,6 +327,7 @@ func handler(res http.ResponseWriter, req *http.Request) {
 
 	// Our web tree.
 	root := pages.NewNode("/", "/", responses.Resps["/"].Titles[lang])
+
 	for _, slug := range slugs {
 		root.AddNode(
 			strings.FieldsFunc(clean, func(c rune) bool { return c == '/' }),
@@ -358,7 +359,7 @@ func handler(res http.ResponseWriter, req *http.Request) {
 	}
 
 	log.Info("Marshaling the response.")
-	buf, err := json.Marshal(r)
+	buf, err := json.Marshal(resp)
 	if err != nil {
 		log.Warnf("handler: unexpected error: %#v\n", err)
 		res.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
Add support for multiple languages in a dir.

~~Currently implemented so that everything should be backwards compatible.~~

To add a new language for a page:
* Choose a language code, e.g. `en`.
* Add a `body_en.md` to your page dir and fill it with content.
* Add a `sidebar_en.md` to your page dir and fill it with content.
* Add a `Title_en` field in the `meta.toml` file and set it to something reasonable

To access a page in the language, add the parameter `?lang=en` to the url
* If there is no content of a specific language, it will return a `json` with a lot of empty fields.

Todo before the PR is finished:
* ~~Decide if this should be backwards compatible.~~
  * ~~If not, we should force all pages to have a `body_sv.md` etc., and possibly add an env. var with the default language if no `GET` parameter is passed.~~
  * ~~I think this is better, but the disadvantage would be that we have to change a lot of file names in both `bawang-content` and `styrdokument` which we could otherwise leave untouched~~
* ~~Add some better error response when a language does not exist for a page.~~
* Possibly clean up a bit.
* update README 

Tbh, I kinda think that parts of this solution is a bit too hacky. I might end up rewriting `pages.Load` and `parseDirs` etc completely. But the interface should be as it is. 